### PR TITLE
Generate and validate safe module, helm and docker names in create cmd

### DIFF
--- a/ignition/templates/factory.py
+++ b/ignition/templates/factory.py
@@ -3,6 +3,7 @@ import jinja2 as jinja
 import random
 import os
 import ignition
+import re
 
 DRIVER_TYPE_VIM = 'VIM'
 DRIVER_TYPE_LIFECYCLE = 'LIFECYCLE'
@@ -32,26 +33,47 @@ class DriverGenRequest:
         self.port = port
         if module_name == None:
             module_name = self.generate_module_name(self.app_name)
+        self.__validate_module_name(module_name)
         self.module_name = module_name
         self.description = description
         if docker_name == None:
             docker_name = self.generate_docker_name(self.app_name)
+        self.__validate_docker_name(docker_name)
         self.docker_name = docker_name
         if helm_name == None:
             helm_name = self.generate_helm_name(self.app_name)
+        self.__validate_helm_name(helm_name)
         self.helm_name = helm_name
         if helm_node_port == None:
             helm_node_port = self.generate_node_port()
         self.helm_node_port = helm_node_port
 
+    def __validate_module_name(self, module_name):
+        if not re.match('^[a-zA-Z0-9]*$', module_name):
+            raise ValueError('module_name must be a string with characters from a-z, A-Z, 0-9 but was: {0}'.format(module_name))
+
+    def __validate_helm_name(self, helm_name):
+        if not re.match('^[a-zA-Z0-9-_]*$', helm_name):
+            raise ValueError('helm_name must be a string with characters from a-z, A-Z, 0-9, dash (-) or underscore (_) but was: {0}'.format(helm_name))
+
+    def __validate_docker_name(self, docker_name):
+        if not re.match('^[a-zA-Z0-9-_]*$', docker_name):
+            raise ValueError('docker_name must be a string with characters from a-z, A-Z, 0-9, dash (-) or underscore (_) but was: {0}'.format(docker_name))
+    
     def generate_helm_name(self, app_name):
-        return app_name.lower().replace(" ", "-")
+        filtered_app_name = re.sub('[^A-Za-z0-9-_ ]+', '', app_name)
+        filtered_app_name = " ".join(filtered_app_name.split())
+        return filtered_app_name.lower().replace(" ", "-")
 
     def generate_docker_name(self, app_name):
-        return app_name.lower().replace(" ", "-")
+        filtered_app_name = re.sub('[^A-Za-z0-9-_ ]+', '', app_name)
+        filtered_app_name = " ".join(filtered_app_name.split())
+        return filtered_app_name.lower().replace(" ", "-")
 
     def generate_module_name(self, app_name):
-        return app_name.lower().replace(" ", "").replace("-", "").replace("_", "")
+        filtered_app_name = re.sub('[^A-Za-z0-9 ]+', '', app_name)
+        filtered_app_name = " ".join(filtered_app_name.split())
+        return filtered_app_name.lower().replace(" ", "")
 
     def generate_port(self):
         return random.randint(7000, 7999)

--- a/ignition/templates/factory.py
+++ b/ignition/templates/factory.py
@@ -61,19 +61,19 @@ class DriverGenRequest:
             raise ValueError('docker_name must be a string with characters from a-z, A-Z, 0-9, dash (-) or underscore (_) but was: {0}'.format(docker_name))
     
     def generate_helm_name(self, app_name):
-        filtered_app_name = re.sub('[^A-Za-z0-9-_ ]+', '', app_name)
-        filtered_app_name = " ".join(filtered_app_name.split())
-        return filtered_app_name.lower().replace(" ", "-")
+        filtered_helm_name = re.sub('[^A-Za-z0-9-_ ]+', '', app_name)
+        filtered_helm_name = " ".join(filtered_helm_name.split())
+        return filtered_helm_name.lower().replace(" ", "-")
 
     def generate_docker_name(self, app_name):
-        filtered_app_name = re.sub('[^A-Za-z0-9-_ ]+', '', app_name)
-        filtered_app_name = " ".join(filtered_app_name.split())
-        return filtered_app_name.lower().replace(" ", "-")
+        filtered_docker_name = re.sub('[^A-Za-z0-9-_ ]+', '', app_name)
+        filtered_docker_name = " ".join(filtered_docker_name.split())
+        return filtered_docker_name.lower().replace(" ", "-")
 
     def generate_module_name(self, app_name):
-        filtered_app_name = re.sub('[^A-Za-z0-9 ]+', '', app_name)
-        filtered_app_name = " ".join(filtered_app_name.split())
-        return filtered_app_name.lower().replace(" ", "")
+        filtered_module_name = re.sub('[^A-Za-z0-9 ]+', '', app_name)
+        filtered_module_name = " ".join(filtered_module_name.split())
+        return filtered_module_name.lower().replace(" ", "")
 
     def generate_port(self):
         return random.randint(7000, 7999)

--- a/tests/unit/templates/test_factory.py
+++ b/tests/unit/templates/test_factory.py
@@ -33,6 +33,52 @@ class TestDriverGenRequest(unittest.TestCase):
         self.assertEqual(request.helm_name, 'test-driver')
         self.assertTrue(request.helm_node_port >= 30000 and request.helm_node_port <= 30999)
 
+    def test_default_module_name(self):
+        request = factory.DriverGenRequest([factory.DRIVER_TYPE_VIM], 'Test-_Special !"£$%^&*()+={}[]:;@~#<>?,./¬ Chars', '0.5.0')
+        self.assertEqual(request.module_name, 'testspecialchars')
+
+    def test_default_helm_name(self):
+        request = factory.DriverGenRequest([factory.DRIVER_TYPE_VIM], 'Test-_Special !"£$%^&*()+={}[]:;@~#<>?,./¬ Chars', '0.5.0')
+        self.assertEqual(request.helm_name, 'test-_special-chars')
+
+    def test_default_docker_name(self):
+        request = factory.DriverGenRequest([factory.DRIVER_TYPE_VIM], 'Test-_Special !"£$%^&*()+={}[]:;@~#<>?,./¬ Chars', '0.5.0')
+        self.assertEqual(request.docker_name, 'test-_special-chars')
+
+    def __do_test_module_name_validation(self, invalid_value):
+        module_name = 'invalid{0}driver'.format(invalid_value)
+        with self.assertRaises(ValueError) as context:
+            factory.DriverGenRequest([factory.DRIVER_TYPE_VIM], 'Test Driver', '0.5.0', module_name=module_name)
+        self.assertEqual(str(context.exception), 'module_name must be a string with characters from a-z, A-Z, 0-9 but was: {0}'.format(module_name))
+
+    def test_module_name_validation(self):
+        for char in '!"£$%^&*()-_+={}[]:;@~#<>?,./¬ ':
+            self.__do_test_module_name_validation(char)
+
+    def __do_test_helm_name_validation(self, invalid_value):
+        helm_name = 'invalid{0}driver'.format(invalid_value)
+        with self.assertRaises(ValueError) as context:
+            factory.DriverGenRequest([factory.DRIVER_TYPE_VIM], 'Test Driver', '0.5.0', helm_name=helm_name)
+        self.assertEqual(str(context.exception), 'helm_name must be a string with characters from a-z, A-Z, 0-9, dash (-) or underscore (_) but was: {0}'.format(helm_name))
+
+    def test_helm_name_validation(self):
+        for char in '!"£$%^&*()+={}[]:;@~#<>?,./¬ ':
+            self.__do_test_helm_name_validation(char)
+        factory.DriverGenRequest([factory.DRIVER_TYPE_VIM], 'Test Driver', '0.5.0', helm_name='dashed-driver')
+        factory.DriverGenRequest([factory.DRIVER_TYPE_VIM], 'Test Driver', '0.5.0', helm_name='underscore_driver')
+
+    def __do_test_docker_name_validation(self, invalid_value):
+        docker_name = 'invalid{0}driver'.format(invalid_value)
+        with self.assertRaises(ValueError) as context:
+            factory.DriverGenRequest([factory.DRIVER_TYPE_VIM], 'Test Driver', '0.5.0', docker_name=docker_name)
+        self.assertEqual(str(context.exception), 'docker_name must be a string with characters from a-z, A-Z, 0-9, dash (-) or underscore (_) but was: {0}'.format(docker_name))
+
+    def test_helm_name_validation(self):
+        for char in '!"£$%^&*()+={}[]:;@~#<>?,./¬ ':
+            self.__do_test_docker_name_validation(char)
+        factory.DriverGenRequest([factory.DRIVER_TYPE_VIM], 'Test Driver', '0.5.0', docker_name='dashed-driver')
+        factory.DriverGenRequest([factory.DRIVER_TYPE_VIM], 'Test Driver', '0.5.0', docker_name='underscore_driver')
+
 
 class TestDriverProducer(unittest.TestCase):
 


### PR DESCRIPTION
Default module, helm and docker names are generated with incompatible characters removed from the app name. 

All user supplied module, helm and docker names are validated for incompatible characters. 

Closes #21 