### PR TITLE
Ensure PropValueMap entries always have a value key

### DIFF
--- a/ignition/utils/propvaluemap.py
+++ b/ignition/utils/propvaluemap.py
@@ -38,6 +38,8 @@ class PropValueMap(MutableMapping):
             if value['type'] == 'key':
                 if value.get('privateKey', None) is None:
                     raise ValueError("Value must have a privateKey property")
+            if 'value' not in value:
+                value['value'] = None
             if key in self:
                 del self.values[key]
             self.values[key] = value

--- a/tests/unit/utils/test_propvalueandtype.py
+++ b/tests/unit/utils/test_propvalueandtype.py
@@ -252,6 +252,12 @@ class TestPropValueAndType(unittest.TestCase):
                 }
             }))
 
-
-
-
+    def test_iter_without_value(self):
+        values = PropValueMap({
+            'prop1': {
+                'type': 'string'
+            }
+        })
+        for k, v in values.items():
+            self.assertEqual(k, 'prop1')
+            self.assertEqual(v, None)


### PR DESCRIPTION
Closes #52 

Fixes KeyError thrown when iterating the map